### PR TITLE
Class PathArgChecker renamed ReactivePathChecker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # path_checker
 
 Before an application uses a path to a file, Python class PathChecker and its
-subclass ArgPathChecker can verify whether the path has the right extension,
-whether it exists and whether it is a directory or a file. In addition,
-ArgPathChecker can warn the user about invalid paths and make correct ones.
-These two classes require pathlib.Path in order to work. This library also
-provides functions that make default values for missing or invalid paths.
+subclass ReactivePathChecker can verify whether the path has the right
+extension, whether it exists and whether it is a directory or a file. In
+addition, ReactivePathChecker can warn the user about invalid paths and make
+correct ones. These two classes require pathlib.Path in order to work. This
+library also provides functions that make default values for missing or
+invalid paths.

--- a/demo.py
+++ b/demo.py
@@ -14,7 +14,8 @@ if __name__ == "__main__":
 	missing_in_warner = MissingPathArgWarner("Argument 1", (".pdf",))
 	try:
 		input_path = Path(argv[1]) # Can raise an IndexError.
-		input_checker = missing_in_warner.make_path_arg_checker(input_path)
+		input_checker =\
+			missing_in_warner.make_reactive_path_checker(input_path)
 
 		input_checker.check_path_exists() # Can raise a FileNotFoundError.
 		input_checker.check_extension_correct() # Can raise a ValueError.
@@ -32,7 +33,8 @@ if __name__ == "__main__":
 	missing_out_warner = MissingPathArgWarner("Argument 2", (".txt",))
 	try:
 		output_path = Path(argv[2]) # Can raise an IndexError.
-		output_checker = missing_out_warner.make_path_arg_checker(output_path)
+		output_checker =\
+			missing_out_warner.make_reactive_path_checker(output_path)
 
 		if output_checker.path_is_dir():
 			output_path = output_path/make_altered_name(

--- a/path_checker/__init__.py
+++ b/path_checker/__init__.py
@@ -1,4 +1,4 @@
 from .missing_path_arg_warner import MissingPathArgWarner
-from .path_arg_checker import PathArgChecker
 from .path_checker import PathChecker
 from .path_util import *
+from .reactive_path_checker import ReactivePathChecker

--- a/path_checker/extension_possessor.py
+++ b/path_checker/extension_possessor.py
@@ -26,8 +26,8 @@ class ExtensionPossessor:
 	@property
 	def extension(self):
 		"""
-		This read-only property is the file extension that this object
-		contains as a tuple of suffixes.
+		This read-only property is a tuple of suffixes that make a file
+		extension.
 		"""
 		return self._extension
 

--- a/path_checker/missing_path_arg_warner.py
+++ b/path_checker/missing_path_arg_warner.py
@@ -1,13 +1,13 @@
 from .extension_possessor import ExtensionPossessor
-from .path_arg_checker import PathArgChecker
 from .path_checker import PathChecker
+from .reactive_path_checker import ReactivePathChecker
 
 
 class MissingPathArgWarner(ExtensionPossessor):
 	"""
 	This class' main purpose is to warn the programmer that a path was not
 	provided to a function or a script as an argument. If a path is given, the
-	class allows to instantiate PathChecker or PathArgChecker. This class
+	class allows to instantiate PathChecker or ReactivePathChecker. This class
 	needs the name of the argument that the path is the value of
 	(property arg_name) and the extension that the path is supposed to have
 	(property extension).
@@ -52,20 +52,6 @@ class MissingPathArgWarner(ExtensionPossessor):
 		return self._arg_name + ": the path to a file with extension '"\
 			+ self.extension_to_str() + "' must be provided."
 
-	def make_path_arg_checker(self, path):
-		"""
-		Creates a PathArgChecker instance with properties extension and
-		arg_name and the given file path.
-
-		Args:
-			path (pathlib.Path or str): It should be the value of the
-				path argument associated with this object.
-
-		Returns:
-			PathArgChecker: an object able to verify the path argument's value
-		"""
-		return PathArgChecker(path, self.extension, self.arg_name)
-
 	def make_path_checker(self, path):
 		"""
 		Creates a PathChecker instance with property extension and the given
@@ -79,3 +65,17 @@ class MissingPathArgWarner(ExtensionPossessor):
 			PathChecker: an object able to verify the path argument's value
 		"""
 		return PathChecker(path, self.extension)
+
+	def make_reactive_path_checker(self, path):
+		"""
+		Creates a ReactivePathChecker instance with properties extension and
+		arg_name and the given file path.
+
+		Args:
+			path (pathlib.Path or str): It should be the value of the
+				path argument associated with this object.
+
+		Returns:
+			ReactivePathChecker: an object able to verify the path argument's value
+		"""
+		return ReactivePathChecker(path, self.extension, self.arg_name)

--- a/path_checker/reactive_path_checker.py
+++ b/path_checker/reactive_path_checker.py
@@ -1,7 +1,7 @@
 from .path_checker import PathChecker
 
 
-class PathArgChecker(PathChecker):
+class ReactivePathChecker(PathChecker):
 	"""
 	In this subclass of PathChecker, the path is considered as an argument
 	given to a fucntion or a script. The class provides methods to warn the

--- a/path_checker/reactive_path_checker.py
+++ b/path_checker/reactive_path_checker.py
@@ -4,8 +4,8 @@ from .path_checker import PathChecker
 class ReactivePathChecker(PathChecker):
 	"""
 	In this subclass of PathChecker, the path is considered as an argument
-	given to a fucntion or a script. The class provides methods to warn the
-	user that the path is invalid and others to make a correct path.
+	given to a fucntion or a script. The class provides methods to react to
+	invalid paths by warning the user or making a correct path.
 	"""
 
 	def __init__(self, a_path, suffixes, arg_name):

--- a/path_checker/reactive_path_checker.py
+++ b/path_checker/reactive_path_checker.py
@@ -31,11 +31,7 @@ class ReactivePathChecker(PathChecker):
 		self._arg_name = arg_name
 
 	def __eq__(self, other):
-		if not isinstance(other, self.__class__):
-			return False
-
-		return self._path == other._path\
-			and self.extension == other.extension\
+		return PathChecker.__eq__(self, other)\
 			and self.arg_name == other.arg_name
 
 	def __repr__(self):


### PR DESCRIPTION
The new name is more evocative of the calss' features. Some improvements to the docstrings were made.